### PR TITLE
switched from pyfits to astropy.io.fits as default.

### DIFF
--- a/PythonPhot/aper.py
+++ b/PythonPhot/aper.py
@@ -5,6 +5,7 @@
 
 example call:
 
+from astropy.io import fits as pyfits
 from PythonPhot import aper
 import numpy as np
 image = pyfits.getdata(fits_filename)

--- a/PythonPhot/getpsf.py
+++ b/PythonPhot/getpsf.py
@@ -8,9 +8,9 @@ from . import make_2d,daoerf, rinter, pkfit, pkfit_noise
 from scipy import linalg
 
 try:
-    import pyfits
-except ImportError:
     import astropy.io.fits as pyfits
+except ImportError:
+    import pyfits
 
 def getpsf(image,xc,yc,
            apmag,sky,ronois,

--- a/PythonPhot/photfunctions.py
+++ b/PythonPhot/photfunctions.py
@@ -11,9 +11,9 @@ the photometry routines (esp. useful for examining residuals after psf fitting)
 import os
 import numpy as np
 try:
-    import pyfits
-except ImportError:
     import astropy.io.fits as pyfits
+except ImportError:
+    import pyfits
 from .aper import aper
 from .cntrd import cntrd
 from .pkfit_norecenter import pkfit_class
@@ -432,8 +432,8 @@ def get_flux_and_err(imagedat, psfmodel, xy, ntestpositions=100, psfradpix=3,
         if np.any(emptyapbias > 0) and verbose:
             print("WARNING: aperture flux may be biased. Empty aperture flux tests"
                   " found a significantly non-zero sky value not accounted for in "
-                  "measurement of the target flux:  \\"
-                  "Mean empty aperture flux in sky annulus = %s\\"
+                  "measurement of the target flux:  \n"
+                  "Mean empty aperture flux in sky annulus = %s\n"
                   % emptyapmeanflux +
                   "sigma of empty aperture flux distribution = %s"
                   % emptyapsigma)

--- a/PythonPhot/pkfit.py
+++ b/PythonPhot/pkfit.py
@@ -63,7 +63,7 @@ RETURNS:
                squares solution, this will be flagged by setting NITER = -1.
 
 EXAMPLE:
-     import pyfits
+     from astropy.io import fits as pyfits
      from PyIDLPhot import pkfit
 
      # read in the FITS images

--- a/PythonPhot/pkfit_noise.py
+++ b/PythonPhot/pkfit_noise.py
@@ -62,8 +62,8 @@ RETURNS:
                squares solution, this will be flagged by setting NITER = -1.
 
 EXAMPLE:
-     import pyfits
-     from PyIDLPhot import pkfit_noise as pkfit
+     from astropy.io import fits as pyfits
+     from PythonPhot import pkfit_noise as pkfit
 
      # read in the FITS images
      image = pyfits.getdata(fits_filename)

--- a/PythonPhot/pkfit_norecent_noise.py
+++ b/PythonPhot/pkfit_norecent_noise.py
@@ -63,8 +63,8 @@ RETURNS:
                squares solution, this will be flagged by setting NITER = -1.
 
 EXAMPLE:
-     import pyfits
-     from PyIDLPhot import pkfit_norecent_noise as pkfit
+     from astropy.io import fits as pyfits
+     from PythonPhot import pkfit_norecent_noise as pkfit
 
      # read in the FITS images
      image = pyfits.getdata(fits_filename)

--- a/PythonPhot/pkfit_norecenter.py
+++ b/PythonPhot/pkfit_norecenter.py
@@ -59,8 +59,8 @@ RETURNS:
                squares solution, this will be flagged by setting NITER = -1.
 
 EXAMPLE:
-     import pyfits
-     from PyIDLPhot import pkfit_norecenter as pkfit
+     from astropy.io import fits as pyfits
+     from PythonPhot import pkfit_norecenter as pkfit
 
      # read in the FITS images
      image = pyfits.getdata(fits_filename)

--- a/PythonPhot/rdpsf.py
+++ b/PythonPhot/rdpsf.py
@@ -5,9 +5,9 @@
 import numpy as np
 from . import dao_value
 try:
-    import pyfits
-except ImportError:
     import astropy.io.fits as pyfits
+except ImportError:
+    import pyfits
 
 def rdpsf(psfname):
     """Read the FITS file created by GETPSF in the DAOPHOT sequence


### PR DESCRIPTION
* The old pyfits package is defunct, and now replaced by the astropy.io.fits package.
  This updates the try/except blocks to import from astropy by default, and only fall back on pyfits
  if there is an ImportError.
* doc strings are also updated to reflect the change in the example code.