### PR TITLE
adding a showfit option to display PSF fit results

### DIFF
--- a/PythonPhot/photfunctions.py
+++ b/PythonPhot/photfunctions.py
@@ -461,7 +461,7 @@ def get_flux_and_err(imagedat, psfmodel, xy, ntestpositions=100, psfradpix=3,
         imagedat = addtoimarray(imagedat, psfmodel, [x, y],
                                 fluxscale=psfflux)
 
-    if debug > 1:
+    if debug is not None:
         import pdb
         pdb.set_trace()
 


### PR DESCRIPTION
in the photutils module, the get_flux_and_err() function now has a keyword option "showfit" which allows the user to display the PSF model and residual image to visually verify the quality of the psf fit. 